### PR TITLE
Fix class autoloading

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -12,6 +12,10 @@ class Controller extends Package
 
     protected $pkgHandle = 'fresh';
 
+    protected $pkgAutoloaderRegistries = [
+        'src' => '\PortlandLabs\Fresh',
+    ];
+
     public function getPackageName()
     {
         return t('Database Seeder / Cleaner');


### PR DESCRIPTION
This PR fixes the following error.

```
Class 'PortlandLabs\Fresh\DatabaseModifier' not found
```
