### PR TITLE
Fix php8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
         }
     ],
     "require": {
-        "fzaninotto/faker": "^1.8",
-        "concrete5/core": "^8.3|dev-8.4.x-dev"
+        "fakerphp/faker": "^1.21"
     },
     "autoload": {
         "psr-4": {

--- a/controller.php
+++ b/controller.php
@@ -12,6 +12,10 @@ class Controller extends Package
 
     protected $pkgHandle = 'fresh';
 
+    protected $pkgAutoloaderRegistries = [
+        'src' => '\PortlandLabs\Fresh',
+    ];
+
     public function getPackageName()
     {
         return t('Database Seeder / Cleaner');
@@ -28,6 +32,12 @@ class Controller extends Package
             $this->app->make('console')->add($this->app->make(SeedCommand::class));
             $this->app->make('console')->add($this->app->make(CleanCommand::class));
         }
+
+        $this->registerAutoload();
     }
 
+    protected function registerAutoload()
+    {
+        require $this->getPackagePath() . '/vendor/autoload.php';
+    }
 }

--- a/src/Console/AbstractCommand.php
+++ b/src/Console/AbstractCommand.php
@@ -17,6 +17,7 @@ abstract class AbstractCommand extends Command
 {
 
     protected $app;
+    protected $parser;
 
     public function __construct(Application $app, $name = null)
     {

--- a/src/Console/AbstractCommand.php
+++ b/src/Console/AbstractCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 abstract class AbstractCommand extends Command
 {
-
+    public const SUCCESS = 0;
     protected $app;
     protected $parser;
 
@@ -117,6 +117,8 @@ abstract class AbstractCommand extends Command
             $this->output = new SymfonyStyle($input, $output);
             return isset($this->app) ? $this->app->call([$this, 'handle']) : $this->handle();
         }
+
+        return self::SUCCESS;
     }
 
     /**


### PR DESCRIPTION
This PR fixes the following exception with PHP 8.x

```
Whoops\Exception\ErrorException: Undefined property: PortlandLabs\Fresh\Console\SeedCommand::$parser in file ......./fresh/src/Console/AbstractCommand.php on line 23
```